### PR TITLE
Remove `npm run build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "homepage": "https://github.com/agnosticful/chipstackoverflow#readme",


### PR DESCRIPTION
Deletes `npm run build`. Because we don't need to run `npm run build` on local. It is supposed to be only on CI